### PR TITLE
Player HP bug fix

### DIFF
--- a/Assets/Prefabs/EnemyPrefab.prefab
+++ b/Assets/Prefabs/EnemyPrefab.prefab
@@ -173,7 +173,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5d20cc51a8370d940bef4773d6a27333, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  damage: 0
   moveSpeed: 0.5
   animator: {fileID: 1288170906316595519}
 --- !u!114 &-7339899325233340433
@@ -190,6 +189,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   health: 1
   animator: {fileID: 1288170906316595519}
+  damage: 1
 --- !u!95 &1288170906316595519
 Animator:
   serializedVersion: 5

--- a/Assets/Scripts/Enemy Scripts/EnemyHealth.cs
+++ b/Assets/Scripts/Enemy Scripts/EnemyHealth.cs
@@ -6,6 +6,7 @@ public class EnemyHealth : MonoBehaviour
 {
     public float health;
     public Animator animator;
+    public int damage;
 
     // Start is called before the first frame update
     void Start()
@@ -44,5 +45,18 @@ public class EnemyHealth : MonoBehaviour
 
         float destroyAnimationDelay = animator.GetCurrentAnimatorStateInfo(0).length;
         Destroy(gameObject, destroyAnimationDelay);
+    }
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        if (collision.CompareTag("Player"))
+        {
+            // deal damage
+            PlayerHealth playerHealth = collision.GetComponent<PlayerHealth>();
+            if (playerHealth != null) playerHealth.TakeDamage(damage);
+
+            // destroy self ('enemy' game object)
+            Destroy(gameObject);
+        }
     }
 }

--- a/Assets/Scripts/Enemy Scripts/EnemyMovement.cs
+++ b/Assets/Scripts/Enemy Scripts/EnemyMovement.cs
@@ -9,7 +9,6 @@ public class EnemyMovement : MonoBehaviour
     private GameObject player;
     private float rotationOffset = -90f;
 
-    public int damage;
     public float moveSpeed;
     public Animator animator;
 
@@ -41,19 +40,6 @@ public class EnemyMovement : MonoBehaviour
 
             // Move the enemy toward the player independently of rotation
             transform.position = Vector2.MoveTowards(transform.position, player.transform.position, moveSpeed * Time.deltaTime);
-        }
-    }
-
-    private void OnTriggerEnter2D(Collider2D collision)
-    {
-        if (collision.CompareTag("Player"))
-        {
-            // deal damage
-            PlayerHealth playerHealth = collision.GetComponent<PlayerHealth>();
-            if (playerHealth != null) playerHealth.TakeDamage(damage);
-
-            // destroy self ('enemy' game object)
-            Destroy(gameObject);
         }
     }
 

--- a/Assets/Scripts/Player Scripts/PlayerHealth.cs
+++ b/Assets/Scripts/Player Scripts/PlayerHealth.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;

--- a/Assets/Scripts/Player Scripts/PlayerShoot.cs
+++ b/Assets/Scripts/Player Scripts/PlayerShoot.cs
@@ -56,7 +56,7 @@ public class PlayerShoot : MonoBehaviour
         Rigidbody2D rb = projectile.GetComponent<Rigidbody2D>();
         rb.velocity = direction * projectileSpeed;
 
-        // ignore collision w/ pl○ayer
+        // ignore collision w/ player
         Collider2D playerCollider = GetComponent<Collider2D>();
         Collider2D projectileCollider = projectile.GetComponent<Collider2D>();
         Physics2D.IgnoreCollision(playerCollider, projectileCollider);


### PR DESCRIPTION
- previously, player HP doesn't decrement upon collision with enemy
- moved player/enemy collision code from 'EnemyMovement' script to 'EnemyHealth' script
- probably shifting code updates the frame more accurately to decrement player HP before destroying itself
- player HP decrements as intended now
- 'game over' displays properly after HP reaches 0
- fixes #29 